### PR TITLE
Fix workspace name resolution and add dashboard URL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,12 +11,6 @@ Use `In` and `Out` structs.
 Use `github.com/cockroachdb/errors` and return wrapped errors: `return out, errors.Wrap(err, "foo")`, `return errors.Wrap(foo(), "foo")`
 Use `github.com/stretchr/testify/assert`: `a := assert.New()`, `r := require.New()`
 
-## Config
-
-## Backing services
-
-## Build, release, run
-
 ## Testing
 
 Write table driven tests with `_name` test cases that assert `a.Equal(tt.out, out)`:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Run `go run main.go` to run cheetah in development mode with live reload. Run `g
 
 ## Roadmap
 
-- [ ] Remote, shared, encrypted config
-- [ ] Internet gateway
+- [x] Remote, shared, encrypted config
+- [ ] Log collector and error callback to agent
 - [ ] Test runner with short, parallel, and error callback optimizations
+- [ ] Internet gateway

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -67,6 +67,6 @@ func Run(in In) (Out, error) {
 		return Out{}, errors.Wrap(err, "run")
 	}
 
-	slog.Info("server", "port", in.Port, "pid", cmd.Process.Pid)
+	slog.Info("server", "port", in.Port, "pid", cmd.Process.Pid, "url", "http://localhost:50000")
 	return Out{Cmd: cmd}, nil
 }

--- a/pkg/code/code.go
+++ b/pkg/code/code.go
@@ -34,12 +34,12 @@ func Code(cfg Config) (Out, error) {
 	var name string
 	if s := cfg.Getenv("SPACE"); s != "" {
 		name = s
-	} else if s := cfg.Getenv("CONDUCTOR_SPACE"); s != "" {
+	} else if s := cfg.Getenv("CONDUCTOR_WORKSPACE_NAME"); s != "" {
 		name = s
 	} else {
 		out, err := cfg.CmdOutput("git", "rev-parse", "--abbrev-ref", "HEAD")
 		if err != nil {
-			return Out{}, errors.Wrap(err, "set SPACE or CONDUCTOR_SPACE env var, or run in a git repo")
+			return Out{}, errors.Wrap(err, "set SPACE or CONDUCTOR_WORKSPACE_NAME env var, or run in a git repo")
 		}
 		branch := strings.ReplaceAll(strings.TrimSpace(out), "/", "-")
 		name = filepath.Base(dir) + "-" + branch

--- a/pkg/code/code_test.go
+++ b/pkg/code/code_test.go
@@ -61,10 +61,10 @@ func TestCode(t *testing.T) {
 			out:   code.Out{Dir: "/projects/auth", Name: "s"},
 		},
 		{
-			_name: "conductor space",
-			dir:   "/workspaces/cheetah/victoria/apps/auth",
-			env:   []string{"CONDUCTOR_SPACE=victoria"},
-			out:   code.Out{Dir: "/workspaces/cheetah/victoria/apps/auth", Name: "victoria"},
+			_name: "conductor workspace name",
+			dir:   "/workspaces/cheetah/caracas/apps/auth",
+			env:   []string{"CONDUCTOR_WORKSPACE_NAME=caracas"},
+			out:   code.Out{Dir: "/workspaces/cheetah/caracas/apps/auth", Name: "caracas"},
 		},
 		{
 			_name: "branch combines with dir",
@@ -88,7 +88,7 @@ func TestCode(t *testing.T) {
 			cmds: map[string]code.CmdResult{
 				"git rev-parse --abbrev-ref HEAD": {Err: "exit status 128"},
 			},
-			err: "set SPACE or CONDUCTOR_SPACE env var, or run in a git repo",
+			err: "set SPACE or CONDUCTOR_WORKSPACE_NAME env var, or run in a git repo",
 		},
 	}
 


### PR DESCRIPTION
- Workspace names now respect Conductor's CONDUCTOR_WORKSPACE_NAME configuration
- Dashboard startup logs now display a clickable URL to access your app