### PR TITLE
Fix localhost DNS resolution and dev mode server management

### DIFF
--- a/pkg/browser/browser_test.go
+++ b/pkg/browser/browser_test.go
@@ -62,7 +62,7 @@ func TestDashboardAndProxy(t *testing.T) {
 		proc.Wait()
 	})
 
-	dashURL := fmt.Sprintf("http://cheetah.localhost:%d", testDashPort)
+	dashURL := fmt.Sprintf("http://localhost:%d", testDashPort)
 	waitForReady(t, dashURL+"/api/status")
 
 	resp := registerApp(t, dashURL, "myapp")

--- a/run.go
+++ b/run.go
@@ -27,7 +27,7 @@ import (
 	"github.com/housecat-inc/cheetah/pkg/watch"
 )
 
-const defaultURL = "http://cheetah.localhost:50000"
+const defaultURL = "http://localhost:50000"
 
 func Run(defaults ...map[string]string) {
 	url := config.EnvOr("CHEETAH_URL", defaultURL)
@@ -313,7 +313,7 @@ func ensureInfra(url string) error {
 	status, err := checkStatus(c, url)
 	running := err == nil
 
-	if running && (latest == "" || latest == status.Version) {
+	if running && (latest == "" || latest == status.Version || status.Version == "dev") {
 		return nil
 	}
 


### PR DESCRIPTION
- Use localhost for direct API access instead of cheetah.localhost subdomain
- Route plain localhost requests to the dashboard API
- Skip automatic server updates when running in dev mode

This resolves DNS lookup issues on macOS and prevents killing dev servers during updates.