### PR TITLE
Add help flags and status command

### DIFF
--- a/pkg/pg/embedded.go
+++ b/pkg/pg/embedded.go
@@ -107,6 +107,10 @@ func Stop(p int) {
 	proc.Signal(syscall.SIGKILL)
 }
 
+func Dial() bool {
+	return dial()
+}
+
 func dial() bool {
 	conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", port), 500*time.Millisecond)
 	if err != nil {


### PR DESCRIPTION
- Add -h/--help and -v/--version flags to cheetah CLI
- Add status command showing cheetah, postgres, and running apps
- Add update command for self-updating
- Improve stop command with backwards-compatible process discovery