### PR TITLE
Improve cheetah update to always fetch latest version

### DIFF
--- a/cmd/cheetah/main.go
+++ b/cmd/cheetah/main.go
@@ -221,6 +221,7 @@ func findPID() int {
 func update() {
 	fmt.Println("updating cheetah...")
 	cmd := exec.Command("go", "install", "github.com/housecat-inc/cheetah/cmd/cheetah@latest")
+	cmd.Env = append(os.Environ(), "GOPROXY=direct")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
The update command now correctly fetches the latest version from source instead of potentially serving cached versions from the module proxy, ensuring users always have the most recent release.