### PR TITLE
Pin embedded postgres to v17 for arm64

### DIFF
--- a/pkg/pg/embedded.go
+++ b/pkg/pg/embedded.go
@@ -55,6 +55,7 @@ func Run() (string, error) {
 
 	db := embeddedpostgres.NewDatabase(
 		embeddedpostgres.DefaultConfig().
+			Version(embeddedpostgres.V17).
 			Port(uint32(port)).
 			DataPath(filepath.Join(dir, fmt.Sprintf("pg-data-%d", port))).
 			RuntimePath(filepath.Join(dir, fmt.Sprintf("pg-runtime-%d", port))).


### PR DESCRIPTION
## Summary
- Pin embedded-postgres to V17 to fix "bad CPU type in executable" on Apple Silicon Macs
- The upstream `zonkyio/embedded-postgres-binaries` v18 darwin-arm64v8 package contains x86_64-only binaries because EnterpriseDB stopped shipping universal macOS binaries starting with Postgres 18
- V17 ships working universal (fat) binaries with both x86_64 and arm64 slices

## Root cause
The zonky `repack-postgres.sh` script downloads the same `postgresql-*-osx-binaries.zip` from EnterpriseDB for both amd64 and arm64v8, assuming the zip contains universal binaries. This assumption broke with Postgres 18.

## Test plan
- [ ] `go run main.go` starts successfully on Apple Silicon Mac
- [ ] Verify `file ~/.cheetah/pg-runtime-*/bin/initdb` shows universal or arm64 binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)